### PR TITLE
Run Acmeair-Loader on a different machine than the one it was compiled on

### DIFF
--- a/acmeair-loader/pom.xml
+++ b/acmeair-loader/pom.xml
@@ -91,6 +91,19 @@
 					<mainClass>com.acmeair.loader.Loader</mainClass>
 				</configuration>
 			</plugin>
-		</plugins>
+                        <plugin>
+		   	  <artifactId>maven-assembly-plugin</artifactId>
+      		  	    <configuration>
+		      	      <archive>
+		                <manifest>
+   		                  <mainClass>com.acmeair.loader.Loader</mainClass>
+		                </manifest>
+                              </archive>
+		              <descriptorRefs>
+		                <descriptorRef>jar-with-dependencies</descriptorRef>
+		              </descriptorRefs>
+		            </configuration>
+   		        </plugin>
+		  </plugins>
 	</build>
 </project>


### PR DESCRIPTION
In acmeair loader I added a configuration for maven assembly to
the pom.xml. This can be used to make jar files if you wish to
run and compile acmeair on different machines